### PR TITLE
Making sure we get the latest code from Kitura-Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+# Travis CI build file for Kitura-redis.
+# Kitura runs on OS X and Linux (Ubuntu v15.10).
+
+# whitelist (branches that should be built)
+branches:
+  only:
+    - master
+    - develop
+    - /^issue.*$/
+
+notifications:
+  slack:
+    secure: "e6LnSUjiA/wZRVaJN9bdbzKrJxtl1D0sBosHs9BERIsek2VMgCN1Z4eFJk9ul/ePIEciaFWgOwJJO9ltC/tRburseDcgzSFNXO1hMasUvA+N3D8wxgnMTdzMnv+F7vbn613kuHFMRFoJFR1TWqahhlUGXvQFvGN+bx2InpZ8qcDmKGbWdk2LgIjF0lm9x+9hAlSKhcO9Dw93qQL8EGkmVJyhoYKL1usJbtpcFiJu6PQhmwM5JSH+5h0GISCoYsv+CKunqcBLfXeFyqT2LuZ1TcWXD3A0PCQQz3imOWhP4eZX9IyQS+E0ypOV8VqvUEyyl0v0Eirmjvh4smTQLlqWVITZe4BGri9+2V4rOocQK8HDbDeH1VuoXa36n9zJDDaMHoixank6n259YFhz5VgekVBMU3lGOvZ4+ax235cmOrF6WtRkY4oN+9AxoZ687A0164l3o+VoPJkpNdu2PZ8n2U2ATfYyqTUwluGPmVhS9YwkhMvDyEOu/EBxG0WcZjlAYQ4Ka2K2hiapulkqACYTeBU5cqMgkY4FOcwXzRqtEBSM0QPSxPFZoF2wNxPFc5DbNBXqRcaBjfyjgXjNhqrbVjHbE0iuM6vtAxXdRU6wrUIKx65cfa6vG/k8rfPG1kBpW2RQtC5s0tsTwBt+4ZUWNbWGzlSe01EkLr5CstzeG/A="
+
+matrix:
+  include:
+    - os: linux
+      services: docker
+      sudo: required
+    - os: osx
+      osx_image: xcode8
+      sudo: required
+
+before_install:
+  - git submodule update --init --remote --merge --recursive
+
+script:
+  - ./Kitura-Build/script_travis.sh $TRAVIS_OS_NAME $TRAVIS_BRANCH $TRAVIS_BUILD_DIR Kitura-CredentialsFacebook

--- a/Makefile
+++ b/Makefile
@@ -19,5 +19,4 @@ export KITURA_CI_BUILD_SCRIPTS_DIR=Kitura-Build/build
 
 Kitura-Build/build/Makefile:
 	@echo --- Fetching Kitura-Build submodule
-	git submodule init
-	git submodule update --remote --merge
+	git submodule update --init --remote --merge --recursive


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
To consolidate logic between travis files and Makefiles to get the latest code for master branch

## Motivation and Context
Updates to makefile were to guarantee that we get the latest master code when we do a make locally.  The changes to to the .travis.yml file were to simplify the before_script section.

## How Has This Been Tested?
Ran the code through Travis CI which builds Kitura on linux and mac.  Also ran a build locally

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [ ] If applicable, I have updated the documentation accordingly.
- [ ] If applicable, I have added tests to cover my changes.
