### PR TITLE
Store the access token in the current session so it can be reused later.

### DIFF
--- a/Sources/CredentialsFacebook/CredentialsFacebook.swift
+++ b/Sources/CredentialsFacebook/CredentialsFacebook.swift
@@ -121,6 +121,8 @@ public class CredentialsFacebook: CredentialsPluginProtocol {
                         try fbResponse.readAllData(into: &body)
                         var jsonBody = JSON(data: body)
                         if let token = jsonBody["access_token"].string {
+                            // Store the token so it can be reused later.
+                            request.session?["facebookAccessToken"] = JSON(token)
                             requestOptions = []
                             requestOptions.append(.schema("https://"))
                             requestOptions.append(.hostname("graph.facebook.com"))

--- a/Sources/CredentialsFacebook/CredentialsFacebookToken.swift
+++ b/Sources/CredentialsFacebook/CredentialsFacebookToken.swift
@@ -82,6 +82,8 @@ public class CredentialsFacebookToken: CredentialsPluginProtocol {
                              inProgress: @escaping () -> Void) {
         if let type = request.headers["X-token-type"], type == name {
             if let token = request.headers["access_token"] {
+                // Store the token so it can be reused later.
+                request.session?["facebookAccessToken"] = JSON(token)
                 #if os(Linux)
                     let key = NSString(string: token)
                 #else


### PR DESCRIPTION
My app needs to do more with Facebook than just log in. I can already request additional permissions by setting the `scope` option but there is currently no way to get a hold of the access token. I'd rather not redirect to Facebook a second time to get a new token, so I made this change to store the access token in the current session.