### PR TITLE
fix: Make OAuth appID optional to allow skipping of verification

### DIFF
--- a/Sources/CredentialsFacebook/FacebookTokenProfile.swift
+++ b/Sources/CredentialsFacebook/FacebookTokenProfile.swift
@@ -45,7 +45,7 @@ public struct FacebookTokenProfile: TypeSafeFacebookToken {
     /// ```swift
     ///     FacebookTokenProfile.appID = "<your OAuth client id>"
     /// ```
-    public static var appID: String = ""
+    public static var appID: String?
 
     /// The application-scoped ID field. Note that this field uniquely identifies a user
     /// wihin the context of the application represented by the token.

--- a/Sources/CredentialsFacebook/TypeSafeFacebookToken.swift
+++ b/Sources/CredentialsFacebook/TypeSafeFacebookToken.swift
@@ -28,7 +28,7 @@ import TypeDecoder
  ### Usage Example: ###
  ```swift
  public struct ExampleProfile: TypeSafeFacebookToken {
-    static var appID: String = "yourAppID"      // The id of your Facebook App
+    static var appID: String? = "yourAppID"     // The id of your Facebook App
     let id: String                              // Protocol requirement
     let name: String                            // Protocol requirement: subject's display name
     let email: String?                          // Optional Facebook field: may not be granted
@@ -137,10 +137,9 @@ extension TypeSafeFacebookToken {
             return onSuccess(cacheProfile)
         }
         // Attempt to validate the supplied token. First check that the token was issued by
-        // the expected OAuth application: this is necessary because the ID returned by
-        // facebook is application-scoped, and so in theory, a user could supply a token
-        // issued by a different OAuth application that contains an ID that collides with
-        // an existing ID issued in the scope of our application.
+        // the expected OAuth application: this is recommended because the ID returned by
+        // facebook is application-scoped. However, the user can choose to skip this and
+        // accept any token by not specifying an appID on their type.
         validateAppID(token: token) { (validID) in
             guard validID else {
                 // Reject any tokens that have not been issued by our OAuth application id (appID).

--- a/Tests/CredentialsFacebookTests/TestTypeSafeToken.swift
+++ b/Tests/CredentialsFacebookTests/TestTypeSafeToken.swift
@@ -56,7 +56,7 @@ class TestTypeSafeToken : XCTestCase {
         var favouriteNumber: Int?
         
         // Static configuration for this type
-        static var appID: String = "123"
+        static var appID: String? = "123"
 
         // Testing requirement: Equatable
         static func == (lhs: TestFacebookToken, rhs: TestFacebookToken) -> Bool {
@@ -78,7 +78,7 @@ class TestTypeSafeToken : XCTestCase {
         var email: String?
 
         // Static configuration for this type
-        static var appID: String = "123"
+        static var appID: String? = "123"
 
         // Cache should only hold two profiles
         static let cacheSize = 2
@@ -105,7 +105,7 @@ class TestTypeSafeToken : XCTestCase {
         var favouriteNumber: Int?
 
         // Static configuration for this type
-        static var appID: String = "123"
+        static var appID: String? = "123"
         
         // Override the field names for the Facebook response, specifically, omitting the
         // 'email' field that would be included by the default filter.


### PR DESCRIPTION
This PR changes the type of `TypeSafeFacebook.appID` from `String` to `String?`, and allows the user to omit the value (defaulting to `nil`).

If the appID is not set, then we will skip the OAuth appID verification step when receiving a token and accept the token regardless of which app it was issued against.  If it is set, then we will continue to verify it as before (rejecting tokens that were not issued to the appID specified).

This change is technically breaking, however it is a correction to the initial implementation and it is unlikely that there are substantial numbers of `TypeSafeFacebookToken` implementers yet.  It is not breaking for users of the pre-defined `FacebookTokenProfile` type.

## Motivation and Context

During the development of #41, we mistakenly believed that there was a risk that the app-scoped ID provided by Facebook could conflict (ie. the same ID value could be issued to two different users for different apps).

This is apparently not the case - the ID is globally unique: https://stackoverflow.com/questions/26643839/is-facebook-app-scoped-id-global-unique

So it is not a security issue (a user cannot accidentally log in as someone else due to ID collision), and so it seems wrong to mandate that the appID is provided.  It's still a useful facility, because the same logical user supplying the wrong token would otherwise resolve successfully to a different ID.

By allowing users to skip this part, it also simplifies use of the built-in `FacebookTokenProfile` type, as the static `FacebookTokenProfile.appID` field no longer needs to be initialized.